### PR TITLE
Eliminate files when file defeatured as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,13 @@ defeature: {
 An object indicating when the defeaturing of a file should result in that file being excluded from output.
 
 #### `removeFileDefeatures.css` boolean
-A flag, when set to `true` (which is the default), will result in the javascript file not being processed any further.  
+A flag, when set to `true` (which is the default), will result in the CSS/SASS file not being processed/written.
 
 #### `removeFileDefeatures.template` boolean
-A flag, when set to `true` (which is the default), will result in the template file being excluded from template processing, which means it will not be merged together by any of Mimosa's template compilers.
+A flag, when set to `true` (which is the default), will result in the template file being excluded from template processing, which means it will not be merged together by any of Mimosa's template compilers.  If set to `false`, defeature will retain `file` excluded templates, and those templates will be used by Mimosa's template compilers as contentless.
 
 #### `removeFileDefeatures.javascript` boolean
-A flag, when set to `true` (which is the default), will result in the CSS/SASS file not being processed/written.
+A flag, when set to `true` (which is the default), will result in the javascript file not being processed any further.  
 
 
 Example Config

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ defeature: {
     child: null
   },
   removeFileDefeatures: {
-    css: true,
     template: true,
     javascript: true
   }
@@ -218,9 +217,6 @@ defeature: {
 
 #### `removeFileDefeatures` object
 An object indicating when the defeaturing of a file should result in that file being excluded from output.
-
-#### `removeFileDefeatures.css` boolean
-A flag, when set to `true` (which is the default), will result in the CSS/SASS file not being processed/written.
 
 #### `removeFileDefeatures.template` boolean
 A flag, when set to `true` (which is the default), will result in the template file being excluded from template processing, which means it will not be merged together by any of Mimosa's template compilers.  If set to `false`, defeature will retain `file` excluded templates, and those templates will be used by Mimosa's template compilers as contentless.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can flag javascript, css, and template code as features. In general, you can
   * `file` Signals that the entire file is part of a feature
 
 ### CSS ###
-The `defeature` module will allow you to defeature plain css files as well as Sass files. You will also be able to use `defeature` with other CSS preprocessors as long as the `@import` behaviour for partials is similar to Sass. One important thing to note when using CSS preprocessors is that the `:file` optional flag will not work as expected so it's best to avoid it. Additionally, when using CSS preprocessors, using a feature comment with no optional flags above an '@import' line will not work as expected, as it will NOT feature flag the entire partial being imported, but instead it will feature flag the first line of the partial.
+The `defeature` module will allow you to defeature plain CSS files as well as SASS files. You will also be able to use `defeature` with other CSS preprocessors as long as the `@import` behaviour for partials is similar to SASS. One important thing to note when using CSS preprocessors is that the `:file` optional flag will not work as expected so it's best to avoid it. Additionally, when using CSS preprocessors, using a feature comment with no optional flags above an '@import' line will not work as expected, as it will NOT feature flag the entire partial being imported, but instead it will feature flag the first line of the partial.
 
 **Note:** The `defeature` module will replace unwanted feature flagged CSS code with empty space (new line characters equaling in number to the lines in the original code). This is done in order for source maps to work as expected when using CSS preprocessors.
 
@@ -142,7 +142,7 @@ Examples:
 Removing features
 =================
 
-Then inclusion or exclusion of features depends on the values present in your `master` and `child` files, which you can specify in the module config. Nested features will result in hyphenated feature names. 
+Then inclusion or exclusion of features depends on the values present in your `master` and `child` files, which you can specify in the module config. Nested features will result in hyphenated feature names.
 
 Examples
 
@@ -192,7 +192,7 @@ The following features will be excluded from the build: 'foo-geo-overlay', 'foo-
 Functionality
 =============
 
-The `defeature` module will remove flagged features from your source code. The module will use `master` and `child` files to determine which features to remove. These files should be in `json` format. The module will look for these files in the `folder` that you specify in the config. You should specify a `child` file if different versions of your application will have different features. Usually, you'll have one child file per version of your app. You can use `mimosa` profiles to switch between versions. 
+The `defeature` module will remove flagged features from your source code. The module will use `master` and `child` files to determine which features to remove. These files should be in `json` format. The module will look for these files in the `folder` that you specify in the config. You should specify a `child` file if different versions of your application will have different features. Usually, you'll have one child file per version of your app. You can use `mimosa` profiles to switch between versions.
 
 If both `master` and `child` are present, `defeature` will perform a smart merge of the two files to determine the final feature list. If only `master` is present, it will use the values in `master` to determine the final feature list. You can nest features in both `master` and `child` files.
 
@@ -207,9 +207,27 @@ defeature: {
   features: {
     master: "master",
     child: null
+  },
+  removeFileDefeatures: {
+    css: true,
+    template: true,
+    javascript: true
   }
 }
 ```
+
+#### `removeFileDefeatures` object
+An object indicating when the defeaturing of a file should result in that file being excluded from output.
+
+#### `removeFileDefeatures.css` boolean
+A flag, when set to `true` (which is the default), will result in the javascript file not being processed any further.  
+
+#### `removeFileDefeatures.template` boolean
+A flag, when set to `true` (which is the default), will result in the template file being excluded from template processing, which means it will not be merged together by any of Mimosa's template compilers.
+
+#### `removeFileDefeatures.javascript` boolean
+A flag, when set to `true` (which is the default), will result in the CSS/SASS file not being processed/written.
+
 
 Example Config
 ==============

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,11 @@ exports.defaults = function() {
       features: {
         master: 'master',
         child: null
+      },
+      removeFileDefeatures: {
+        css: true,
+        template: true,
+        javascript: true
       }
     }
   };
@@ -16,6 +21,7 @@ exports.defaults = function() {
 
 exports.validate = function( config, validators )  {
   var errors = [];
+  
   if ( validators.ifExistsIsObject( errors, "defeature config", config.defeature ) ) {
     if ( validators.ifExistsIsString( errors, "defeature.folder", config.defeature.folder ) ) {
       config.defeature.folderFull = path.join( config.root, config.defeature.folder );
@@ -25,6 +31,14 @@ exports.validate = function( config, validators )  {
       validators.ifExistsIsString( errors, "defeature.features.master", config.defeature.features.master );
       validators.ifExistsIsString( errors, "defeature.features.child", config.defeature.features.child );
     }
+
+    if ( validators.ifExistsIsObject( errors, "defeature.removeFileDefeatures", config.defeature.removeFileDefeatures ) ) {
+      var rfd = config.defeature.removeFileDefeatures;
+      validators.ifExistsIsBoolean( errors, "defeature.removeFileDefeatures.css", rfd.css );
+      validators.ifExistsIsBoolean( errors, "defeature.removeFileDefeatures.template", rfd.template );
+      validators.ifExistsIsBoolean( errors, "defeature.removeFileDefeatures.javascript", rfd.javascript );
+    }
+
   }
 
   return errors;

--- a/src/config.js
+++ b/src/config.js
@@ -14,24 +14,13 @@ exports.defaults = function() {
   };
 };
 
-
-exports.placeholder = function () {
-  var ph = "\n\n  defeature:            # Configuration for removing features from the application \n" +
-     "    folder:'feature'              # Path to folder containing feature files \n\n" +
-     "    features: \n" +
-     "      master:'master'             # Name of json file containing all of the possible features the app makes available \n\n " +
-     "      child: null                 # Optionally, a json file that selectively excludes features present in the master file  \n";
-
-  return ph;
-};
-
 exports.validate = function( config, validators )  {
   var errors = [];
   if ( validators.ifExistsIsObject( errors, "defeature config", config.defeature ) ) {
     if ( validators.ifExistsIsString( errors, "defeature.folder", config.defeature.folder ) ) {
       config.defeature.folderFull = path.join( config.root, config.defeature.folder );
     }
-    
+
     if ( validators.ifExistsIsObject( errors, "defeature.features", config.defeature.features ) ) {
       validators.ifExistsIsString( errors, "defeature.features.master", config.defeature.features.master );
       validators.ifExistsIsString( errors, "defeature.features.child", config.defeature.features.child );

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,6 @@ exports.defaults = function() {
         child: null
       },
       removeFileDefeatures: {
-        css: true,
         template: true,
         javascript: true
       }
@@ -21,7 +20,7 @@ exports.defaults = function() {
 
 exports.validate = function( config, validators )  {
   var errors = [];
-  
+
   if ( validators.ifExistsIsObject( errors, "defeature config", config.defeature ) ) {
     if ( validators.ifExistsIsString( errors, "defeature.folder", config.defeature.folder ) ) {
       config.defeature.folderFull = path.join( config.root, config.defeature.folder );
@@ -34,7 +33,6 @@ exports.validate = function( config, validators )  {
 
     if ( validators.ifExistsIsObject( errors, "defeature.removeFileDefeatures", config.defeature.removeFileDefeatures ) ) {
       var rfd = config.defeature.removeFileDefeatures;
-      validators.ifExistsIsBoolean( errors, "defeature.removeFileDefeatures.css", rfd.css );
       validators.ifExistsIsBoolean( errors, "defeature.removeFileDefeatures.template", rfd.template );
       validators.ifExistsIsBoolean( errors, "defeature.removeFileDefeatures.javascript", rfd.javascript );
     }

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,5 @@ var registration = function( mimosaConfig, register ) {
 module.exports = {
   registration: registration,
   defaults:     config.defaults,
-  placeholder:  config.placeholder,
   validate:     config.validate
 };

--- a/src/lib/template.js
+++ b/src/lib/template.js
@@ -7,10 +7,10 @@ var logger = null;
 var _defeature = function( mimosaConfig, options, next ) {
   if ( options.files && options.files.length ) {
 
-    // if need to remove blank templates, set up newFiles array
-    var newFiles;
+    // if need to remove blank templates, set up keepFiles array
+    var keepFiles;
     if (mimosaConfig.defeature.removeFileDefeatures.template) {
-      newFiles = [];
+      keepFiles = [];
     }
 
     options.files.forEach( function( file ) {
@@ -34,23 +34,24 @@ var _defeature = function( mimosaConfig, options, next ) {
         });
         finalSource += source.slice(start, source.length);
         file.inputFileText = finalSource;
-        // newFiles array exists, and the file has content
-        // add file to newFiles.  This leaves out any files
+        // keepFiles array exists, and the file has content
+        // add file to keepFiles.  This leaves out any files
         // that have length = 0.
-        if(newFiles && finalSource.length && finalSource.length > 0) {
-          newFiles.push(file);
+        if(keepFiles && finalSource.length && finalSource.length > 0) {
+          keepFiles.push(file);
         }
       } else {
-        // no updates, leave it alone
-        if(newFiles) {
-          newFiles.push(file);
+        // if removing files, need to put unchanged files into list
+        // of files to keep
+        if(keepFiles) {
+          keepFiles.push(file);
         }
       }
     });
 
-    // if newfiles, reset file list.
-    if(newFiles) {
-      options.files = newFiles;
+    // if removing files, reset file list.
+    if(keepFiles) {
+      options.files = keepFiles;
     }
   }
 

--- a/src/lib/template.js
+++ b/src/lib/template.js
@@ -6,7 +6,14 @@ var logger = null;
 
 var _defeature = function( mimosaConfig, options, next ) {
   if ( options.files && options.files.length ) {
-    options.files.forEach( function( file ) { 
+
+    // if need to remove blank templates, set up newFiles array
+    var newFiles;
+    if (mimosaConfig.defeature.removeFileDefeatures.template) {
+      newFiles = [];
+    }
+
+    options.files.forEach( function( file ) {
       // remove ranges from source
       var finalSource = "";
       var source = file.inputFileText;
@@ -27,8 +34,24 @@ var _defeature = function( mimosaConfig, options, next ) {
         });
         finalSource += source.slice(start, source.length);
         file.inputFileText = finalSource;
+        // newFiles array exists, and the file has content
+        // add file to newFiles.  This leaves out any files
+        // that have length = 0.
+        if(newFiles && finalSource.length && finalSource.length > 0) {
+          newFiles.push(file);
+        }
+      } else {
+        // no updates, leave it alone
+        if(newFiles) {
+          newFiles.push(file);
+        }
       }
     });
+
+    // if newfiles, reset file list.
+    if(newFiles) {
+      options.files = newFiles;
+    }
   }
 
   next();


### PR DESCRIPTION
1. Removed the `placeholder` stuff as it is deprecated and will be removed as a requirement with Mimosa `3.0`
2. Added flags for templates and javascript such that when files of those types are `:file` defeatured and the flags are set to `true`, the file will be omitted from the files to be considered for output.  If a template is  `:file` defeatured it will no longer be in the list of templates to concatenate, if javascript is `:file` defeatured it will be removed from the `options.files` array.
3. I set the flags to `true` by default, which modifies current behavior.  Think this is the right default to have, and if set to `false` it behaves as it has been.  This will necessitate a major version in create.  Might be time for `1.0`?
4. I left out not writing CSS files as that got hairy and makes less sense since, generally, the recommendation is to not attempt to file defeature CSS files.