### PR TITLE
Allow build v watch defeaturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ If both `master` and `child` are present, `defeature` will perform a smart merge
 
 `mimosa` will remove features when your run `mimosa watch` or `mimosa build`.
 
+## `build` v `watch` exclusion
+
+A feature called `mimosa-build-exclude` is automatically recognized by mimosa-defeature. This included feature allows for excluding features based on whether Mimosa is running a `watch` or a `build`.  When running a `build`, all code using the `mimosa-build-exclude` feature flag will be removed/commented.
+
 Default Config
 ======
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,15 @@ var _prepareFeatures = function(mimosaConfig, options, next) {
   mimosaConfig.defeature.includedFeatures = includedFeatures;
   mimosaConfig.defeature.excludedFeatures = excludedFeatures;
 
+  // when running a build, add feature that
+  // allows defeaturing to be build v watch specific
+  // Allows for leaving things in for dev that need removing for build
+  if (mimosaConfig.isBuild) {
+    excludedFeatures.push("mimosa-build-exclude");
+  } else {
+    includedFeatures.push("mimosa-build-exclude");
+  }
+
   next();
 };
 


### PR DESCRIPTION
Occasionally there are things that are necessary in development that you do not want to, or cannot, include in a built application.

There are several ways one could omit that sort of thing, but this simple addition to your module would allow someone to use deafeaturing to flag things that need to be left out of builds.

We specifically need this to allow us to omit certain test parameters that we use when running tests locally vs when we run tests during CI.