### PR TITLE
allow defeature based on NODE_ENV flag of production

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ If both `master` and `child` are present, `defeature` will perform a smart merge
 
 A feature called `mimosa-build-exclude` is automatically recognized by mimosa-defeature. This included feature allows for excluding features based on whether Mimosa is running a `watch` or a `build`.  When running a `build`, all code using the `mimosa-build-exclude` feature flag will be removed/commented.
 
+## `NODE_ENV=production`
+
+An `environment-production` feature is automatically __included__ if `NODE_ENV` is set to `production`.  Otherwise the `environment-production` feature is automatically __excluded__.
+
 Default Config
 ======
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,16 @@ var _prepareFeatures = function(mimosaConfig, options, next) {
     includedFeatures.push("mimosa-build-exclude");
   }
 
+  // allow for defeaturing based on NODE_ENV
+  // lets someone pick/choose lines of code based
+  // on destination. Assume not production unless
+  // explicitly defined
+  if(process.env.NODE_ENV && process.env.NODE_ENV === "production") {
+    includedFeatures.push("environment-production");
+  } else {
+    excludedFeatures.push("environment-production");
+  }
+
   next();
 };
 


### PR DESCRIPTION
An `environment-production` feature is automatically __included__ if `NODE_ENV` is set to `production`.  Otherwise the `environment-production` feature is automatically __excluded__.