### PR TITLE
Upgrading dependencies to version that support ES2015 module syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "lodash": "2.4.1",
-    "rocambole": "git://github.com/millermedeiros/rocambole#v0.4.0",
+    "rocambole": "^0.6.0",
     "rocambole-token": "1.2.1"
   },
   "license": "MIT",

--- a/src/lib/javascript.js
+++ b/src/lib/javascript.js
@@ -192,7 +192,7 @@ var _defeature = function( mimosaConfig, options, next ) {
       var keep = true;
       if(shouldDefeatureFile) {
         try {
-          var ast = rocambole.parse(file.inputFileText);
+          var ast = rocambole.parse(file.inputFileText, { sourceType: "module" });
           var keepFile = _commentOutExcludedFeatures(mimosaConfig, ast, includedFeatures, excludedFeatures);
 
           // _commentOutExcludedFeatures will return false if the file has been


### PR DESCRIPTION
Switched to rocambole 0.6 (which pulls in esprima 2.2).  Esprima 2.2 requires option `sourceType: 'module'` in order to support the module syntax.
